### PR TITLE
fix: export TypeormAdapter from main package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export * from './lib/types/Identity'
 export * from './lib/types/CrudModuleOptions'
 export * from './lib/types/Upload'
 export * from './lib/utils/localFileStorage'
+export { TypeormAdapter } from './lib/adapters/typeorm.adapter'
 
 // Utilities
 export * from './lib/utils/swaggerSchema'


### PR DESCRIPTION
- Add TypeormAdapter export to src/index.ts
- Fixes TypeScript compilation error in example projects
- Resolves 'TypeormAdapter' has no exported member error